### PR TITLE
license: readable with encoding=ascii

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Pavel Dedík
+Copyright (c) 2016, Pavel Dedik
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Without this change I am unable to install this library.


```
Collecting neon-py==0.1.3 (from -r ./requirements-alembic.txt (line 4))
Collecting neon-py==0.1.3 (from -r ./requirements-alembic.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/4d/25/dc0121748240c80ebdf64fdc5d2595ed4b83a2db0d85e5e42912704c244b/neon-py-0.1.3.tar.gz
  Downloading https://files.pythonhosted.org/packages/4d/25/dc0121748240c80ebdf64fdc5d2595ed4b83a2db0d85e5e42912704c244b/neon-py-0.1.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-5zobxybu/neon-py/setup.py", line 23, in <module>
        license=open('LICENSE').read(),
      File "/home/afs/venv/lib64/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 29: ordinal not in range(128)
```